### PR TITLE
Make sure deploy script changes branch before deploy

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -3,12 +3,26 @@
 SOURCE_BRANCH=`git rev-parse --abbrev-ref HEAD`
 DEST_BRANCH=gh-pages
 
-echo $SOURCE_BRANCH
 git checkout $DEST_BRANCH
+
+# Make sure we actually made it to the destination branch
+if [ `git rev-parse --abbrev-ref HEAD` != $DEST_BRANCH ]; then
+  echo "!!!! Something went wrong check the errors above and try again !!!!"
+  exit 0
+fi
+
+# Checkout code to deploy on destination branch
 git reset --hard $SOURCE_BRANCH
+
+# Prepare build dependencies
 bower install
+
+# ignore .gitignore and commit build dependencies
 git add --force bower_components
 git commit -m "add bower components"
+
+# Overwrite the destination branch
 git push origin $DEST_BRANCH --force
 
+# Like nothing ever happened
 git checkout $SOURCE_BRANCH

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "text selection.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "iojs server.js"
+    "start": "iojs server.js",
+    "deploy": "./bin/deploy.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds a check to make sure we made it to the destination branch before we make any destructive changes.

Add a convenience command to package.json so you can do `npm run deploy` from your current branch to deploy
